### PR TITLE
Update VTG parsing for NMEA0183 version 2.3 and later

### DIFF
--- a/RMC.CPP
+++ b/RMC.CPP
@@ -163,6 +163,7 @@ RMC const& RMC::operator = ( RMC const& source ) noexcept
    Date                       = source.Date;
    MagneticVariation          = source.MagneticVariation;
    MagneticVariationDirection = source.MagneticVariationDirection;
+   FAAMode                    = source.FAAMode;
 
   return( *this );
 }

--- a/VTG.CPP
+++ b/VTG.CPP
@@ -65,12 +65,31 @@ bool VTG::Parse( SENTENCE const& sentence ) noexcept
    /*
    ** First we check the checksum...
    */
+   
+   int checksum_field = 9;
 
-   if ( sentence.IsChecksumBad( 9 ) == NMEA0183_BOOLEAN::True )
+   // Version 2.3 of the standard has things different
+
+   FAAMode = sentence.FAAMode(9);
+
+   if (FAAMode != FAA_MODE::ModeUnknown)
+   {
+       checksum_field = 10;
+   }
+
+   auto const check = sentence.IsChecksumBad(checksum_field);
+
+   if ( check == NMEA0183_BOOLEAN::True )
    {
        SetErrorMessage(STRING_VIEW("Invalid Checksum"));
        return( false );
-   } 
+   }
+
+   if (check == NMEA0183_BOOLEAN::NMEA_Unknown)
+   {
+       SetErrorMessage(STRING_VIEW("Missing Checksum"));
+       return(false);
+   }
 
    TrackDegreesTrue       = sentence.Double( 1 );
    TrackDegreesMagnetic   = sentence.Double( 3 );
@@ -108,6 +127,7 @@ VTG const& VTG::operator = ( VTG const& source ) noexcept
    TrackDegreesMagnetic   = source.TrackDegreesMagnetic;
    SpeedKnots             = source.SpeedKnots;
    SpeedKilometersPerHour = source.SpeedKilometersPerHour;
+   FAAMode                = source.FAAMode;
 
    return( *this );
 }

--- a/VTG.HPP
+++ b/VTG.HPP
@@ -44,10 +44,11 @@ class VTG : public RESPONSE
       ** Data
       */
 
-      double TrackDegreesTrue{ 0.0 };
-      double TrackDegreesMagnetic{ 0.0 };
-      double SpeedKnots{ 0.0 };
-      double SpeedKilometersPerHour{ 0.0 };
+      double   TrackDegreesTrue{ 0.0 };
+      double   TrackDegreesMagnetic{ 0.0 };
+      double   SpeedKnots{ 0.0 };
+      double   SpeedKilometersPerHour{ 0.0 };
+      FAA_MODE FAAMode{ FAA_MODE::ModeUnknown };
 
       /*
       ** Methods


### PR DESCRIPTION
See https://github.com/SammyB428/NMEA0183/issues/1#issuecomment-1029013481

I tried to replicate the fix in RMC.HPP and RMC.CPP for the same issue (FAA mode indicator). I've also added a missing assignment for the = operator in RMC.CPP.

Example sentence NMEA0183 ver 2.3 and later:

```
$GNVTG,348.78,T,,M,0.03,N,0.05,K,D*20
$GNVTG,348.78,T,,M,0.07,N,0.13,K,D*23
$GNVTG,348.78,T,,M,0.10,N,0.19,K,D*2F
$GNVTG,348.78,T,,M,0.05,N,0.09,K,D*2A
$GNVTG,348.78,T,,M,0.10,N,0.18,K,D*2E
```

The `D` in the 9th field is the FAA mode indicator, with the checksum moved to field 10.

The same problem probably exists for the BWC, BWR, GLL, RMA, RMB, WCV, and XTE sentences. For now, VTG is the only one I've had a chance to fix and test.